### PR TITLE
Switching double quotes for backticks in startup/linux.js so substitution works.

### DIFF
--- a/src/startup/linux.js
+++ b/src/startup/linux.js
@@ -27,7 +27,7 @@ export function add (name, cmd, args, out) {
     '[Desktop Entry]',
     'Type=Application',
     'Vestion=1.0',
-    'Name=${name}',
+    `Name=${name}`,
     `Comment=${name} startup script`,
     `Exec=${cmd} ${args} > ${out}`,
     'StartupNotify=false',


### PR DESCRIPTION
Simple fix. I was getting the `${name}` in my autostart scripts. Thanks!
