### PR TITLE
Add exec permission

### DIFF
--- a/src/startup/linux.js
+++ b/src/startup/linux.js
@@ -59,6 +59,7 @@ function add (name, cmd, args = [], out) {
 
   mkdirp.sync(dir)
   fs.writeFileSync(file, data)
+  fs.chmodSync('test', '+x');
   return file
 }
 

--- a/src/startup/linux.js
+++ b/src/startup/linux.js
@@ -59,7 +59,7 @@ function add (name, cmd, args = [], out) {
 
   mkdirp.sync(dir)
   fs.writeFileSync(file, data)
-  fs.chmodSync('test', '+x');
+  fs.chmodSync(file, '+x');
   return file
 }
 


### PR DESCRIPTION
Adds permission to execute file, avoiding startup errors in Ubuntu/linux OS.